### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/PangleAdapterBannerAd.swift
+++ b/Source/PangleAdapterBannerAd.swift
@@ -35,7 +35,7 @@ final class PangleAdapterBannerAd: PangleAdapterAd, PartnerAd {
                 self.log(.loadSucceeded)
                 completion(.success([:]))
             } else {
-                let error = self.error(.loadFailureUnknown, error: partnerError)
+                let error = partnerError ?? self.error(.loadFailureUnknown)
                 self.log(.loadFailed(error))
                 completion(.failure(error))
             }   

--- a/Source/PangleAdapterInterstitialAd.swift
+++ b/Source/PangleAdapterInterstitialAd.swift
@@ -31,7 +31,7 @@ final class PangleAdapterInterstitialAd: PangleAdapterAd, PartnerAd {
                 self.log(.loadSucceeded)
                 completion(.success([:]))
             } else {
-                let error = self.error(.loadFailureUnknown, error: partnerError)
+                let error = partnerError ?? self.error(.loadFailureUnknown)
                 self.log(.loadFailed(error))
                 completion(.failure(error))
             }

--- a/Source/PangleAdapterRewardedAd.swift
+++ b/Source/PangleAdapterRewardedAd.swift
@@ -31,7 +31,7 @@ final class PangleAdapterRewardedAd: PangleAdapterAd, PartnerAd {
                 self.log(.loadSucceeded)
                 completion(.success([:]))
             } else {
-                let error = self.error(.loadFailureUnknown, error: partnerError)
+                let error = partnerError ?? self.error(.loadFailureUnknown)
                 self.log(.loadFailed(error))
                 completion(.failure(error))
             }


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
