### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/PangleAdapter.swift
+++ b/Source/PangleAdapter.swift
@@ -8,10 +8,10 @@
 //  ChartboostHeliumAdapterPangle
 //
 
+import ChartboostMediationSDK
 import Foundation
-import UIKit
-import HeliumSdk
 import PAGAdSDK
+import UIKit
 
 /// The Helium Pangle adapter.
 final class PangleAdapter: PartnerAdapter {

--- a/Source/PangleAdapterAd.swift
+++ b/Source/PangleAdapterAd.swift
@@ -8,10 +8,10 @@
 //  ChartboostHeliumAdapterPangle
 //
 
+import BUAdSDK
+import ChartboostMediationSDK
 import Foundation
 import UIKit
-import HeliumSdk
-import BUAdSDK
 
 /// Base class for Helium Pangle adapter ads.
 class PangleAdapterAd: NSObject {

--- a/Source/PangleAdapterBannerAd.swift
+++ b/Source/PangleAdapterBannerAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterPangle
 //
 
+import ChartboostMediationSDK
 import Foundation
 import PAGAdSDK
-import HeliumSdk
 
 /// The Helium Pangle adapter banner ad.
 final class PangleAdapterBannerAd: PangleAdapterAd, PartnerAd {

--- a/Source/PangleAdapterInterstitialAd.swift
+++ b/Source/PangleAdapterInterstitialAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterPangle
 //
 
+import ChartboostMediationSDK
 import Foundation
 import PAGAdSDK
-import HeliumSdk
 
 /// The Helium Pangle adapter interstitial ad.
 final class PangleAdapterInterstitialAd: PangleAdapterAd, PartnerAd {

--- a/Source/PangleAdapterRewardedAd.swift
+++ b/Source/PangleAdapterRewardedAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterPangle
 //
 
+import ChartboostMediationSDK
 import Foundation
 import PAGAdSDK
-import HeliumSdk
 
 /// The Helium Pangle adapter rewarded ad.
 final class PangleAdapterRewardedAd: PangleAdapterAd, PartnerAd {


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.