### PR TITLE
HB-5462: Support new ad format cases without warnings

### DIFF
--- a/Source/PangleAdapter.swift
+++ b/Source/PangleAdapter.swift
@@ -118,7 +118,7 @@ final class PangleAdapter: PartnerAdapter {
             return PangleAdapterRewardedAd(adapter: self, request: request, delegate: delegate)
         case .banner:
             return PangleAdapterBannerAd(adapter: self, request: request, delegate: delegate)
-        @unknown default:
+        default:
             throw error(.loadFailureUnsupportedAdFormat)
         }
     }


### PR DESCRIPTION
Removed the  keyword from the default case when switching on ad format, preventing warnings when new formats are introduced on newer Chartboost Mediation SDK versions.\nThe plan is to just merge this to main, and create new patch releases later on with the first 4.3 RCs with whatever the latest adapter version is.