### PR TITLE
HB-6740: Add base privacy manifest

### DIFF
--- a/ChartboostMediationAdapterPangle.podspec
+++ b/ChartboostMediationAdapterPangle.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   # Source
   spec.module_name  = 'ChartboostMediationAdapterPangle'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-pangle.git', :tag => spec.version }
+  spec.resource_bundles = { 'ChartboostMediationAdapterPangle' => ['PrivacyInfo.xcprivacy'] }
   spec.source_files = 'Source/**/*.{swift}'
 
   # Minimum supported versions

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6740

For the Pangle adapter, the privacy manifest can be bare-bones.