### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/PangleAdapterBannerAd.swift
+++ b/Source/PangleAdapterBannerAd.swift
@@ -25,7 +25,8 @@ final class PangleAdapterBannerAd: PangleAdapterAd, PartnerBannerAd {
         log(.loadStarted)
 
         // Fail if we cannot fit a fixed size banner in the requested size.
-        guard let loadedSize = fixedBannerSize(for: request.bannerSize) else {
+        guard let requestedSize = request.bannerSize,
+              let loadedSize = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize)?.size else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
             return completion(.failure(error))
@@ -65,25 +66,5 @@ extension PangleAdapterBannerAd: PAGBannerAdDelegate {
     
     func adDidDismiss(_ ad: PAGAdProtocol) {
         log(.delegateCallIgnored)
-    }
-}
-
-// MARK: - Helpers
-extension PangleAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: BannerSize?) -> CGSize? {
-        guard let requestedSize else {
-            return IABStandardAdSize
-        }
-        let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
-        // Find the largest size that can fit in the requested size.
-        for size in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return size
-            }
-        }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)